### PR TITLE
Fix shorthand token parsing to prevent false Molar matches

### DIFF
--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/util/TeethNotationUtil.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/util/TeethNotationUtil.java
@@ -281,21 +281,26 @@ public class TeethNotationUtil {
         }
 
 
-        // Check for combined location and type
+        // Check for combined location and type. Split the shorthand into
+        // distinct tokens to avoid matching substrings (e.g. matching
+        // "Molar" inside "Premolar").
+        Set<String> tokens = new HashSet<>(Arrays.asList(shorthand.split("\\s+|\\+")));
+        tokens.removeIf(String::isEmpty);
+
         Set<Integer> result = new HashSet<>();
         boolean hasLocation = false;
         boolean hasType = false;
 
         // Check for location
-        if (shorthand.contains("Upper")) {
+        if (tokens.contains("Upper")) {
             result.addAll(UPPER);
             hasLocation = true;
-        } else if (shorthand.contains("Lower")) {
+        } else if (tokens.contains("Lower")) {
             result.addAll(LOWER);
             hasLocation = true;
         }
 
-        if (shorthand.contains("Left")) {
+        if (tokens.contains("Left")) {
             if (hasLocation) {
                 // Intersect with existing result
                 result.retainAll(LEFT);
@@ -303,7 +308,7 @@ public class TeethNotationUtil {
                 result.addAll(LEFT);
                 hasLocation = true;
             }
-        } else if (shorthand.contains("Right")) {
+        } else if (tokens.contains("Right")) {
             if (hasLocation) {
                 // Intersect with existing result
                 result.retainAll(RIGHT);
@@ -314,7 +319,7 @@ public class TeethNotationUtil {
         }
 
         // Check for type
-        if (shorthand.contains("Wisdom")) {
+        if (tokens.contains("Wisdom")) {
             if (hasLocation) {
                 // Intersect with existing result
                 Set<Integer> intersection = new HashSet<>(result);
@@ -325,7 +330,7 @@ public class TeethNotationUtil {
             }
             hasType = true;
         }
-        if (shorthand.contains("Molar")) {
+        if (tokens.contains("Molar")) {
             if (hasLocation || hasType) {
                 // Intersect with existing result
                 Set<Integer> intersection = new HashSet<>(result);
@@ -336,7 +341,7 @@ public class TeethNotationUtil {
             }
             hasType = true;
         }
-        if (shorthand.contains("Premolar")) {
+        if (tokens.contains("Premolar")) {
             if (hasLocation || hasType) {
                 // Intersect with existing result
                 Set<Integer> intersection = new HashSet<>(result);
@@ -347,7 +352,7 @@ public class TeethNotationUtil {
             }
             hasType = true;
         }
-        if (shorthand.contains("Canine")) {
+        if (tokens.contains("Canine")) {
             if (hasLocation || hasType) {
                 // Intersect with existing result
                 Set<Integer> intersection = new HashSet<>(result);
@@ -358,7 +363,7 @@ public class TeethNotationUtil {
             }
             hasType = true;
         }
-        if (shorthand.contains("Incisor")) {
+        if (tokens.contains("Incisor")) {
             if (hasLocation || hasType) {
                 // Intersect with existing result
                 Set<Integer> intersection = new HashSet<>(result);

--- a/rivergreen-ap/src/test/java/com/stkych/rivergreenap/util/TeethNotationUtilTest.java
+++ b/rivergreen-ap/src/test/java/com/stkych/rivergreenap/util/TeethNotationUtilTest.java
@@ -106,4 +106,9 @@ public class TeethNotationUtilTest {
         String lowerRight = "25-26-27-28-29-30-31-32";
         assertEquals("Lower Right", TeethNotationUtil.toShorthand(lowerRight));
     }
+
+    @Test
+    public void testFromShorthandUpperLeftPremolar() {
+        assertEquals("13-14", TeethNotationUtil.fromShorthand("Upper Left Premolar"));
+    }
 }


### PR DESCRIPTION
## Summary
- prevent `fromShorthand` from matching substrings like `Molar` within `Premolar` by tokenizing the shorthand input
- add regression test for `fromShorthand("Upper Left Premolar")`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a43593bb08327893fac854cafc2a2