### PR TITLE
Correct premolar tooth sets and update tests

### DIFF
--- a/rivergreen-ap/shorthand.txt
+++ b/rivergreen-ap/shorthand.txt
@@ -1,7 +1,7 @@
 "TYPE" sets
 "Wisdom" = 1 + 16 + 17 + 32
 "Molar" = 2 + 3 + 14 + 15 + 18 + 19 + 30 + 31
-"Premolar" = 3 + 4 + 13 + 14 + 20 + 21 + 28 + 29
+"Premolar" = 4 + 5 + 12 + 13 + 20 + 21 + 28 + 29
 "Canine" = 6 + 11 + 22 + 27
 "Incisor" = 7 + 8 + 9 + 10 + 23 + 24 + 25 + 26
 "Upper" = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15 + 16
@@ -10,7 +10,7 @@
 "Lower Wisdom" = 17 + 32
 "Upper Molar" = 2 + 3 + 14 + 15
 "Lower Molar" = 18 + 19 + 30 + 31
-"Upper Premolar" = 3 + 4 + 13 + 14
+"Upper Premolar" = 4 + 5 + 12 + 13
 "Lower Premolar" = 20 + 21 + 28 + 29
 "Upper Canine" = 6 + 11
 "Lower Canine" = 22 + 27

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/util/TeethNotationUtil.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/util/TeethNotationUtil.java
@@ -11,7 +11,9 @@ public class TeethNotationUtil {
     // Type sets - using exact names from shorthand.txt
     private static final Set<Integer> WISDOM = new HashSet<>(Arrays.asList(1, 16, 17, 32));
     private static final Set<Integer> MOLAR = new HashSet<>(Arrays.asList(2, 3, 14, 15, 18, 19, 30, 31));
-    private static final Set<Integer> PREMOLAR = new HashSet<>(Arrays.asList(3, 4, 13, 14, 20, 21, 28, 29));
+    // Premolars were previously defined incorrectly and overlapped with molars.
+    // Correct numbering: 4,5,12,13,20,21,28,29
+    private static final Set<Integer> PREMOLAR = new HashSet<>(Arrays.asList(4, 5, 12, 13, 20, 21, 28, 29));
     private static final Set<Integer> CANINE = new HashSet<>(Arrays.asList(6, 11, 22, 27));
     private static final Set<Integer> INCISOR = new HashSet<>(Arrays.asList(7, 8, 9, 10, 23, 24, 25, 26));
 
@@ -20,7 +22,7 @@ public class TeethNotationUtil {
     private static final Set<Integer> LOWER_WISDOM = new HashSet<>(Arrays.asList(17, 32));
     private static final Set<Integer> UPPER_MOLAR = new HashSet<>(Arrays.asList(2, 3, 14, 15));
     private static final Set<Integer> LOWER_MOLAR = new HashSet<>(Arrays.asList(18, 19, 30, 31));
-    private static final Set<Integer> UPPER_PREMOLAR = new HashSet<>(Arrays.asList(3, 4, 13, 14));
+    private static final Set<Integer> UPPER_PREMOLAR = new HashSet<>(Arrays.asList(4, 5, 12, 13));
     private static final Set<Integer> LOWER_PREMOLAR = new HashSet<>(Arrays.asList(20, 21, 28, 29));
     private static final Set<Integer> UPPER_CANINE = new HashSet<>(Arrays.asList(6, 11));
     private static final Set<Integer> LOWER_CANINE = new HashSet<>(Arrays.asList(22, 27));

--- a/rivergreen-ap/src/test/java/com/stkych/rivergreenap/util/TeethNotationUtilTest.java
+++ b/rivergreen-ap/src/test/java/com/stkych/rivergreenap/util/TeethNotationUtilTest.java
@@ -8,11 +8,11 @@ public class TeethNotationUtilTest {
     @Test
     public void testToShorthandPremolars() {
         // Test with all premolars
-        String allPremolars = "3-4-13-14-20-21-28-29";
+        String allPremolars = "4-5-12-13-20-21-28-29";
         assertEquals("Premolar", TeethNotationUtil.toShorthand(allPremolars));
 
         // Test with a subset of premolars
-        String somePremolars = "3-4-13-14";
+        String somePremolars = "4-5-12-13";
         assertEquals("Upper Premolar", TeethNotationUtil.toShorthand(somePremolars));
 
         // Test with lower premolars


### PR DESCRIPTION
## Summary
- correct premolar tooth numbers so they no longer overlap with molars
- adjust unit tests to reflect accurate premolar sets
- fix shorthand reference file with accurate premolar definitions

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b591155d4832782e7f525afbd8e04