### PR TITLE
feat: expand ruleset editing and codes

### DIFF
--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
@@ -38,12 +38,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Controller for the main.fxml scene of the application.
@@ -767,6 +770,9 @@ public class ControllerMain extends Controller {
         for (int i = 1; i < ruleset.size(); i++) {
             RulesetItem item = ruleset.get(i);
             String procedureCode = item.getProcedureCode();
+            Set<String> ruleCodes = Arrays.stream(procedureCode.split("[;\\s]+"))
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toSet());
             String priority = item.getPriority();
             String diagnosis = item.getDiagnosis();
 
@@ -788,8 +794,8 @@ public class ControllerMain extends Controller {
             for (int j = 1; j < procedures.size(); j++) { // Skip the header item (index 0)
                 TreatmentPlanProcedure procedure = procedures.get(j);
 
-                // Check if procedure code matches
-                if (procedure.getProcedureCode().equals(procedureCode)) {
+                // Check if procedure code matches any of the rule codes
+                if (ruleCodes.contains(procedure.getProcedureCode())) {
                     // If the rule has teeth specified, check if the procedure's tooth matches any of them
                     if (!ruleTeeth.isEmpty()) {
                         String procedureTooth = procedure.getToothNumber();

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/cells/RulesetItemListCell.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/cells/RulesetItemListCell.java
@@ -8,8 +8,10 @@ import javafx.scene.control.ListCell;
 import javafx.scene.layout.GridPane;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * Custom ListCell implementation for displaying RulesetItem objects
@@ -64,16 +66,25 @@ public class RulesetItemListCell extends ListCell<RulesetItem> {
         } else {
             // Set the text of each label to the corresponding property of the item
             priorityLabel.setText(item.getPriority());
-            procedureCodeLabel.setText(item.getProcedureCode());
 
-            // Use the teeth numbers property and convert to shorthand if possible
+            // Display teeth numbers without shorthand.
+            // Convert ranges (e.g. "1-3;5") to their comma form and append
+            // the original range representation in parentheses when applicable.
             String teethNumbers = item.getTeethNumbers();
-            String teethDisplay = TeethNotationUtil.toShorthand(teethNumbers).replace(";", ",");
+            List<Integer> expanded = TeethNotationUtil.expandTeeth(teethNumbers);
+            String commaForm = expanded.isEmpty()
+                    ? teethNumbers.replace(";", ",")
+                    : expanded.stream().map(String::valueOf).collect(Collectors.joining(","));
+            String teethDisplay = commaForm;
+            if (!expanded.isEmpty() && !teethNumbers.replace(";", ",").equals(commaForm)) {
+                teethDisplay = commaForm + " (" + teethNumbers.replace(";", ",") + ")";
+            }
             teethLabel.setText(teethDisplay);
 
-            // Set the diagnosis and description
+            // Display procedure code and description
+            procedureCodeLabel.setText(item.getProcedureCode().replace(";", ","));
             String description = item.getDescription();
-            diagnosisLabel.setText(item.getDiagnosis()); // Use the actual diagnosis
+            diagnosisLabel.setText(item.getDiagnosis());
             descriptionLabel.setText(description);
 
             // Set the graphic to the gridPane

--- a/rivergreen-ap/src/main/resources/com/stkych/rivergreenap/ruleset_dialog.fxml
+++ b/rivergreen-ap/src/main/resources/com/stkych/rivergreenap/ruleset_dialog.fxml
@@ -34,6 +34,7 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
 
@@ -91,6 +92,21 @@
                      </VBox.margin>
                   </Label>
                   <ComboBox fx:id="priorityComboBox" editable="true" prefWidth="250.0" promptText="Priority" />
+               </children>
+               <padding>
+                  <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+               </padding>
+            </VBox>
+
+            <!-- Row 3: Description (optional) -->
+            <VBox alignment="CENTER" GridPane.columnSpan="2" GridPane.rowIndex="2">
+               <children>
+                  <Label text="Description" textAlignment="CENTER">
+                     <VBox.margin>
+                        <Insets bottom="5.0" />
+                     </VBox.margin>
+                  </Label>
+                  <TextField fx:id="descriptionTextField" promptText="Description (optional)" />
                </children>
                <padding>
                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />


### PR DESCRIPTION
## Summary
- show expanded teeth ranges without shorthand in ruleset list
- support multiple dental codes and optional descriptions in ruleset dialog and CSV
- display comma and range forms for teeth in rule editor

## Testing
- `mvn -q -f rivergreen-ap/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bb6d51b908327917644a24ceb31eb