### PR TITLE
Handle conditional priority in ruleset

### DIFF
--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
@@ -649,6 +649,9 @@ public class ControllerMain extends Controller {
                     String diagnosis = "";
                     String teethNumbers = "";
                     String procedureCode = "";
+                    boolean isDependent = false;
+                    String conditionalPriority = "";
+                    String newPriority = "";
 
                     // Get diagnosis if present
                     if (parts.length > 1 && !parts[1].trim().isEmpty()) {
@@ -678,6 +681,17 @@ public class ControllerMain extends Controller {
                         teethNumbers = parts.length > 2 ? parts[2].trim() : "";
                     }
 
+                    // Get conditional fields if present
+                    if (parts.length > 4 && !parts[4].trim().isEmpty()) {
+                        isDependent = Boolean.parseBoolean(parts[4].trim());
+                    }
+                    if (parts.length > 5 && !parts[5].trim().isEmpty()) {
+                        conditionalPriority = parts[5].trim();
+                    }
+                    if (parts.length > 6 && !parts[6].trim().isEmpty()) {
+                        newPriority = parts[6].trim();
+                    }
+
                     // Always fetch description from the database
                     String description = "";
                     try {
@@ -689,10 +703,8 @@ public class ControllerMain extends Controller {
                         LOGGER.log(Level.WARNING, "Error getting procedure description", e);
                     }
 
-                    RulesetItem item = new RulesetItem(priority, procedureCode, description, teethNumbers);
-                    if (!diagnosis.isEmpty()) {
-                        item.setDiagnosis(diagnosis);
-                    }
+                    RulesetItem item = new RulesetItem(priority, procedureCode, description, teethNumbers, diagnosis,
+                            isDependent, conditionalPriority, newPriority);
                     items.add(item);
                 }
             }
@@ -769,6 +781,9 @@ public class ControllerMain extends Controller {
             String procedureCode = item.getProcedureCode();
             String priority = item.getPriority();
             String diagnosis = item.getDiagnosis();
+            boolean isDependent = item.isDependent();
+            String conditionalPriority = item.getConditionalPriority();
+            String newPriority = item.getNewPriority();
 
             // Only use diagnosis if it's explicitly specified in the ruleset
             // Don't use description as fallback
@@ -794,26 +809,48 @@ public class ControllerMain extends Controller {
                     if (!ruleTeeth.isEmpty()) {
                         String procedureTooth = procedure.getToothNumber();
                         if (procedureTooth != null && !procedureTooth.isEmpty() && ruleTeeth.contains(procedureTooth)) {
-                            // Update priority and diagnosis if both procedure code and tooth match
-                            procedure.setPriority(priority);
+                            boolean shouldApply = true;
+                            if (isDependent) {
+                                String currentPriority = procedure.getPriority();
+                                if (conditionalPriority != null && !conditionalPriority.isEmpty() &&
+                                        !conditionalPriority.equals(currentPriority)) {
+                                    shouldApply = false;
+                                }
+                            }
 
-                            // Use the diagnosis property
+                            if (shouldApply) {
+                                String targetPriority = isDependent && newPriority != null && !newPriority.isEmpty()
+                                        ? newPriority : priority;
+                                procedure.setPriority(targetPriority);
+
+                                if (diagnosis != null && !diagnosis.isEmpty()) {
+                                    procedure.setDiagnosis(diagnosis);
+                                }
+
+                                appliedCount++;
+                            }
+                        }
+                    } else {
+                        boolean shouldApply = true;
+                        if (isDependent) {
+                            String currentPriority = procedure.getPriority();
+                            if (conditionalPriority != null && !conditionalPriority.isEmpty() &&
+                                    !conditionalPriority.equals(currentPriority)) {
+                                shouldApply = false;
+                            }
+                        }
+
+                        if (shouldApply) {
+                            String targetPriority = isDependent && newPriority != null && !newPriority.isEmpty()
+                                    ? newPriority : priority;
+                            procedure.setPriority(targetPriority);
+
                             if (diagnosis != null && !diagnosis.isEmpty()) {
                                 procedure.setDiagnosis(diagnosis);
                             }
 
                             appliedCount++;
                         }
-                    } else {
-                        // If the rule doesn't specify teeth, update all procedures with matching code
-                        procedure.setPriority(priority);
-
-                        // Also update diagnosis even if no teeth are specified
-                        if (diagnosis != null && !diagnosis.isEmpty()) {
-                            procedure.setDiagnosis(diagnosis);
-                        }
-
-                        appliedCount++;
                     }
                 }
             }

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerRuleset.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerRuleset.java
@@ -691,6 +691,9 @@ public class ControllerRuleset implements Initializable {
                     String diagnosis = "";
                     String teethNumbers = "";
                     String procedureCode = "";
+                    boolean isDependent = false;
+                    String conditionalPriority = "";
+                    String newPriority = "";
 
                     // Get diagnosis if present
                     if (parts.length > 1 && !parts[1].trim().isEmpty()) {
@@ -720,6 +723,16 @@ public class ControllerRuleset implements Initializable {
                         teethNumbers = parts.length > 2 ? parts[2].trim() : "";
                     }
 
+                    if (parts.length > 4 && !parts[4].trim().isEmpty()) {
+                        isDependent = Boolean.parseBoolean(parts[4].trim());
+                    }
+                    if (parts.length > 5 && !parts[5].trim().isEmpty()) {
+                        conditionalPriority = parts[5].trim();
+                    }
+                    if (parts.length > 6 && !parts[6].trim().isEmpty()) {
+                        newPriority = parts[6].trim();
+                    }
+
                     // Always fetch description from the database
                     String description = "";
                     try {
@@ -731,10 +744,8 @@ public class ControllerRuleset implements Initializable {
                         LOGGER.log(Level.SEVERE, "Unexpected error", e);
                     }
 
-                    RulesetItem item = new RulesetItem(priority, procedureCode, description, teethNumbers);
-                    if (!diagnosis.isEmpty()) {
-                        item.setDiagnosis(diagnosis);
-                    }
+                    RulesetItem item = new RulesetItem(priority, procedureCode, description, teethNumbers, diagnosis,
+                            isDependent, conditionalPriority, newPriority);
                     items.add(item);
                 }
             }
@@ -798,6 +809,19 @@ public class ControllerRuleset implements Initializable {
                         procedureCode = procedureCode.substring(1);
                     }
                     line.append(procedureCode);
+                }
+
+                // Append conditional fields
+                line.append(",").append(item.isDependent());
+                line.append(",");
+                String conditionalPriority = item.getConditionalPriority();
+                if (conditionalPriority != null && !conditionalPriority.isEmpty()) {
+                    line.append(conditionalPriority);
+                }
+                line.append(",");
+                String newPriority = item.getNewPriority();
+                if (newPriority != null && !newPriority.isEmpty()) {
+                    line.append(newPriority);
                 }
 
                 writer.write(line.toString());

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/model/RulesetItem.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/model/RulesetItem.java
@@ -1,5 +1,7 @@
 package com.stkych.rivergreenap.model;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import java.util.Objects;
@@ -15,6 +17,9 @@ public class RulesetItem {
     private final StringProperty description;
     private final StringProperty teethNumbers;
     private final StringProperty diagnosis;
+    private final BooleanProperty dependent;
+    private final StringProperty conditionalPriority;
+    private final StringProperty newPriority;
 
     /**
      * Constructs a new RulesetItem with the specified values.
@@ -25,11 +30,7 @@ public class RulesetItem {
      * @param teethNumbers The teeth numbers as a comma-separated list
      */
     public RulesetItem(String priority, String procedureCode, String description, String teethNumbers) {
-        this.priority = new SimpleStringProperty(priority);
-        this.procedureCode = new SimpleStringProperty(procedureCode);
-        this.description = new SimpleStringProperty(description);
-        this.teethNumbers = new SimpleStringProperty(teethNumbers);
-        this.diagnosis = new SimpleStringProperty("");
+        this(priority, procedureCode, description, teethNumbers, "", false, "", "");
     }
 
     /**
@@ -63,11 +64,31 @@ public class RulesetItem {
      * @param diagnosis The diagnosis for the item
      */
     public RulesetItem(String priority, String procedureCode, String description, String teethNumbers, String diagnosis) {
+        this(priority, procedureCode, description, teethNumbers, diagnosis, false, "", "");
+    }
+
+    /**
+     * Constructs a new RulesetItem with all available values.
+     *
+     * @param priority            The priority of the item
+     * @param procedureCode       The procedure code
+     * @param description         The description of the procedure code
+     * @param teethNumbers        The teeth numbers as a comma-separated list
+     * @param diagnosis           The diagnosis for the item
+     * @param isDependent         Whether this rule is dependent on the existing priority
+     * @param conditionalPriority The priority that must be present for the rule to apply
+     * @param newPriority         The priority to set when the condition is met
+     */
+    public RulesetItem(String priority, String procedureCode, String description, String teethNumbers, String diagnosis,
+                       boolean isDependent, String conditionalPriority, String newPriority) {
         this.priority = new SimpleStringProperty(priority);
         this.procedureCode = new SimpleStringProperty(procedureCode);
         this.description = new SimpleStringProperty(description);
         this.teethNumbers = new SimpleStringProperty(teethNumbers);
         this.diagnosis = new SimpleStringProperty(diagnosis);
+        this.dependent = new SimpleBooleanProperty(isDependent);
+        this.conditionalPriority = new SimpleStringProperty(conditionalPriority);
+        this.newPriority = new SimpleStringProperty(newPriority);
     }
 
     // Priority property
@@ -135,6 +156,45 @@ public class RulesetItem {
         this.diagnosis.set(diagnosis);
     }
 
+    // Dependent property
+    public BooleanProperty dependentProperty() {
+        return dependent;
+    }
+
+    public boolean isDependent() {
+        return dependent.get();
+    }
+
+    public void setDependent(boolean isDependent) {
+        this.dependent.set(isDependent);
+    }
+
+    // Conditional priority property
+    public StringProperty conditionalPriorityProperty() {
+        return conditionalPriority;
+    }
+
+    public String getConditionalPriority() {
+        return conditionalPriority.get();
+    }
+
+    public void setConditionalPriority(String conditionalPriority) {
+        this.conditionalPriority.set(conditionalPriority);
+    }
+
+    // New priority property
+    public StringProperty newPriorityProperty() {
+        return newPriority;
+    }
+
+    public String getNewPriority() {
+        return newPriority.get();
+    }
+
+    public void setNewPriority(String newPriority) {
+        this.newPriority.set(newPriority);
+    }
+
     /**
      * Returns a string representation of this RulesetItem.
      *
@@ -148,6 +208,9 @@ public class RulesetItem {
                 ", description='" + getDescription() + '\'' +
                 ", teethNumbers='" + getTeethNumbers() + '\'' +
                 ", diagnosis='" + getDiagnosis() + '\'' +
+                ", isDependent='" + isDependent() + '\'' +
+                ", conditionalPriority='" + getConditionalPriority() + '\'' +
+                ", newPriority='" + getNewPriority() + '\'' +
                 '}';
     }
 
@@ -160,11 +223,15 @@ public class RulesetItem {
                 Objects.equals(getProcedureCode(), that.getProcedureCode()) &&
                 Objects.equals(getDescription(), that.getDescription()) &&
                 Objects.equals(getTeethNumbers(), that.getTeethNumbers()) &&
-                Objects.equals(getDiagnosis(), that.getDiagnosis());
+                Objects.equals(getDiagnosis(), that.getDiagnosis()) &&
+                Objects.equals(isDependent(), that.isDependent()) &&
+                Objects.equals(getConditionalPriority(), that.getConditionalPriority()) &&
+                Objects.equals(getNewPriority(), that.getNewPriority());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getPriority(), getProcedureCode(), getDescription(), getTeethNumbers(), getDiagnosis());
+        return Objects.hash(getPriority(), getProcedureCode(), getDescription(), getTeethNumbers(), getDiagnosis(),
+                isDependent(), getConditionalPriority(), getNewPriority());
     }
 }


### PR DESCRIPTION
## Summary
- Add `isDependent`, `conditionalPriority`, and `newPriority` fields to `RulesetItem`
- Load and persist the new fields in ruleset controllers
- Apply conditional priority updates when applying rulesets to procedures

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a36a2900d88327b2fd545553c2839a