### PR TITLE
Include D/N prefixes in dental code CSV handling

### DIFF
--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
@@ -789,16 +789,20 @@ public class ControllerMain extends Controller {
 
                     // Get procedure code if present
                     if (parts.length > 3 && !parts[3].trim().isEmpty()) {
-                        // Add 'D' prefix if not present
                         procedureCode = parts[3].trim();
-                        if (!procedureCode.startsWith("D")) {
-                            procedureCode = "D" + procedureCode;
+                        if (!procedureCode.isEmpty()) {
+                            char first = Character.toUpperCase(procedureCode.charAt(0));
+                            if (first != 'D' && first != 'N') {
+                                procedureCode = "D" + procedureCode;
+                            }
                         }
                     }
 
                     // Handle old format files (priority,procedureCode,teethNumbers,diagnosis)
                     // Check if we have a valid procedure code in the second position
-                    if (diagnosis.startsWith("D") && (procedureCode.isEmpty() || !procedureCode.startsWith("D"))) {
+                    if ((diagnosis.startsWith("D") || diagnosis.startsWith("N")) &&
+                            (procedureCode.isEmpty() ||
+                             !(procedureCode.startsWith("D") || procedureCode.startsWith("N")))) {
                         // This is likely the old format
                         procedureCode = diagnosis;
                         diagnosis = parts.length > 3 ? parts[3].trim() : "";

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerRuleset.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerRuleset.java
@@ -4,6 +4,7 @@ import com.stkych.rivergreenap.RiverGreenDB;
 import com.stkych.rivergreenap.SceneSwitcher;
 import com.stkych.rivergreenap.controller.cells.RulesetItemCellFactory;
 import com.stkych.rivergreenap.model.RulesetItem;
+import com.stkych.rivergreenap.util.DentalCodeUtil;
 import com.stkych.rivergreenap.util.FileUtils;
 import com.stkych.rivergreenap.util.TeethNotationUtil;
 import javafx.collections.FXCollections;
@@ -846,10 +847,13 @@ public class ControllerRuleset implements Initializable {
                             String code = codes[i].trim();
                             System.out.println("[DEBUG_LOG] Processing code #" + (i+1) + ": '" + code + "'");
 
-                            // Add 'D' prefix if not present
-                            if (!code.startsWith("D")) {
-                                code = "D" + code;
-                                System.out.println("[DEBUG_LOG] Added 'D' prefix: '" + code + "'");
+                            // Add letter prefix if missing (default to D)
+                            if (!code.isEmpty()) {
+                                char first = Character.toUpperCase(code.charAt(0));
+                                if (first != 'D' && first != 'N') {
+                                    code = "D" + code;
+                                    System.out.println("[DEBUG_LOG] Added default 'D' prefix: '" + code + "'");
+                                }
                             }
                             formattedCodes.append(code);
                             if (i < codes.length - 1) {
@@ -983,34 +987,14 @@ public class ControllerRuleset implements Initializable {
                 }
                 line.append(",");
 
-                // Add procedure codes (without 'D' prefix)
+                // Add procedure codes, preserving letter prefixes and compressing ranges
                 String procedureCodes = item.getProcedureCodes();
                 System.out.println("[DEBUG_LOG] Saving procedure codes to CSV for item #" + i + ": '" + procedureCodes + "'");
 
                 if (procedureCodes != null && !procedureCodes.isEmpty()) {
-                    // Process comma-separated procedure codes
-                    String[] codes = procedureCodes.split(",");
-                    System.out.println("[DEBUG_LOG] Split into " + codes.length + " codes for formatting");
-
-                    StringBuilder formattedCodes = new StringBuilder();
-                    for (int j = 0; j < codes.length; j++) {
-                        String code = codes[j].trim();
-                        System.out.println("[DEBUG_LOG] Processing code #" + (j+1) + ": '" + code + "'");
-
-                        // Remove 'D' prefix if present
-                        if (code.startsWith("D")) {
-                            code = code.substring(1);
-                            System.out.println("[DEBUG_LOG] Removed 'D' prefix: '" + code + "'");
-                        }
-                        formattedCodes.append(code);
-                        if (j < codes.length - 1) {
-                            formattedCodes.append(";");
-                        }
-                    }
-
-                    String result = formattedCodes.toString();
-                    System.out.println("[DEBUG_LOG] Formatted procedure codes for CSV: '" + result + "'");
-                    line.append(result);
+                    String compressed = DentalCodeUtil.compressDentalCodes(procedureCodes);
+                    System.out.println("[DEBUG_LOG] Compressed procedure codes for CSV: '" + compressed + "'");
+                    line.append(compressed);
                 }
                 line.append(",");
 

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/util/DentalCodeUtil.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/util/DentalCodeUtil.java
@@ -149,7 +149,7 @@ public class DentalCodeUtil {
 
     /**
      * Compresses a list of dental codes into a compact representation using ranges, per prefix.
-     * Example: [D3000, D3001, D3002] -> "D3000-3002"; [N2300, N2301] -> "N2300-2301".
+     * Example: [D3000, D3001, D3002] -> "D3000-D3002"; [N2300, N2301] -> "N2300-N2301".
      * Uses semicolons as delimiters between ranges and preserves the code letter (D/N).
      *
      * @param codes The list of dental codes to compress
@@ -189,7 +189,7 @@ public class DentalCodeUtil {
                     if (start == prev) {
                         out.append(String.format("%c%04d", letter, start));
                     } else {
-                        out.append(String.format("%c%04d-%04d", letter, start, prev));
+                        out.append(String.format("%c%04d-%c%04d", letter, start, letter, prev));
                     }
                     start = cur;
                 }
@@ -200,7 +200,7 @@ public class DentalCodeUtil {
             if (start == prev) {
                 out.append(String.format("%c%04d", letter, start));
             } else {
-                out.append(String.format("%c%04d-%04d", letter, start, prev));
+                out.append(String.format("%c%04d-%c%04d", letter, start, letter, prev));
             }
         }
         return out.toString();


### PR DESCRIPTION
## Summary
- ensure dental code compression outputs letter on both range bounds
- preserve D/N prefixes when reading and writing ruleset CSV files
- recognize N-prefixed codes when importing legacy rulesets

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a36f3071d083278135ff04b0b408ad