### PR TITLE
Fix ruleset dependency parsing in main controller

### DIFF
--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
@@ -767,29 +767,45 @@ public class ControllerMain extends Controller {
                 // Debug: Print the entire CSV line
                 System.out.println("[DEBUG_LOG] CSV Loading - Entire line: " + line);
 
-                // Split by comma
-                String[] parts = line.split(",");
+                // Handle quoted fields (for description)
+                List<String> parts = new ArrayList<>();
+                StringBuilder sb = new StringBuilder();
+                boolean inQuotes = false;
 
-                if (parts.length >= 2) {
-                    // New format: priority,diagnosis,teeth,codes
-                    String priority = parts[0].trim();
+                for (int i = 0; i < line.length(); i++) {
+                    char c = line.charAt(i);
+
+                    if (c == '"') {
+                        inQuotes = !inQuotes;
+                        if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                            sb.append('"');
+                            i++;
+                        }
+                    } else if (c == ',' && !inQuotes) {
+                        parts.add(sb.toString());
+                        sb.setLength(0);
+                    } else {
+                        sb.append(c);
+                    }
+                }
+                parts.add(sb.toString());
+
+                if (parts.size() >= 2) {
+                    // New format: priority,diagnosis,teeth,codes,description,dependent,conditionalPriority,newPriority
+                    String priority = parts.get(0).trim();
                     String diagnosis = "";
                     String teethNumbers = "";
                     String procedureCode = "";
+                    String description = "";
 
-                    // Get diagnosis if present
-                    if (parts.length > 1 && !parts[1].trim().isEmpty()) {
-                        diagnosis = parts[1].trim();
+                    if (parts.size() > 1 && !parts.get(1).trim().isEmpty()) {
+                        diagnosis = parts.get(1).trim();
                     }
-
-                    // Get teeth numbers if present
-                    if (parts.length > 2 && !parts[2].trim().isEmpty()) {
-                        teethNumbers = parts[2].trim();
+                    if (parts.size() > 2 && !parts.get(2).trim().isEmpty()) {
+                        teethNumbers = parts.get(2).trim();
                     }
-
-                    // Get procedure code if present
-                    if (parts.length > 3 && !parts[3].trim().isEmpty()) {
-                        procedureCode = parts[3].trim();
+                    if (parts.size() > 3 && !parts.get(3).trim().isEmpty()) {
+                        procedureCode = parts.get(3).trim();
                         if (!procedureCode.isEmpty()) {
                             char first = Character.toUpperCase(procedureCode.charAt(0));
                             if (first != 'D' && first != 'N') {
@@ -797,33 +813,52 @@ public class ControllerMain extends Controller {
                             }
                         }
                     }
+                    if (parts.size() > 4 && !parts.get(4).trim().isEmpty()) {
+                        description = parts.get(4).trim();
+                    }
+
+                    boolean dependent = false;
+                    if (parts.size() > 5 && !parts.get(5).trim().isEmpty()) {
+                        dependent = Boolean.parseBoolean(parts.get(5).trim());
+                    }
+
+                    String conditionalPriority = "";
+                    if (parts.size() > 6 && !parts.get(6).trim().isEmpty()) {
+                        conditionalPriority = parts.get(6).trim();
+                    }
+
+                    String newPriority = "";
+                    if (parts.size() > 7 && !parts.get(7).trim().isEmpty()) {
+                        newPriority = parts.get(7).trim();
+                    }
 
                     // Handle old format files (priority,procedureCode,teethNumbers,diagnosis)
-                    // Check if we have a valid procedure code in the second position
                     if ((diagnosis.startsWith("D") || diagnosis.startsWith("N")) &&
                             (procedureCode.isEmpty() ||
                              !(procedureCode.startsWith("D") || procedureCode.startsWith("N")))) {
                         // This is likely the old format
                         procedureCode = diagnosis;
-                        diagnosis = parts.length > 3 ? parts[3].trim() : "";
-                        teethNumbers = parts.length > 2 ? parts[2].trim() : "";
+                        diagnosis = parts.size() > 3 ? parts.get(3).trim() : "";
+                        teethNumbers = parts.size() > 2 ? parts.get(2).trim() : "";
                     }
 
-                    // Always fetch description from the database
-                    String description = "";
-                    try {
-                        if (!procedureCode.isEmpty()) {
-                            description = RiverGreenDB.getProcedureCodeDescription(procedureCode);
+                    if (description.isEmpty()) {
+                        try {
+                            if (!procedureCode.isEmpty()) {
+                                description = RiverGreenDB.getProcedureCodeDescription(procedureCode);
+                            }
+                        } catch (SQLException e) {
+                            LOGGER.log(Level.WARNING, "Error getting procedure description", e);
                         }
-                    } catch (SQLException e) {
-                        // If there's an error, use an empty description
-                        LOGGER.log(Level.WARNING, "Error getting procedure description", e);
                     }
 
                     RulesetItem item = new RulesetItem(priority, procedureCode, description, teethNumbers);
                     if (!diagnosis.isEmpty()) {
                         item.setDiagnosis(diagnosis);
                     }
+                    item.setDependent(dependent);
+                    item.setConditionalPriority(conditionalPriority);
+                    item.setNewPriority(newPriority);
                     items.add(item);
                 }
             }


### PR DESCRIPTION
## Summary
- Parse and store `dependent`, `conditionalPriority`, and `newPriority` fields when loading rulesets in `ControllerMain`
- Handle quoted CSV fields so rule descriptions and dependency data are read correctly

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a374386a9c8327aa93c38ced338092