### PR TITLE
Parameterize database connection details

### DIFF
--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/DatabaseConfig.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/DatabaseConfig.java
@@ -1,0 +1,11 @@
+package com.stkych.rivergreenap;
+
+/**
+ * Configuration values for connecting to the database.
+ */
+public class DatabaseConfig {
+    public static final String DB_URL = "jdbc:mysql://localhost:3306/opendental?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC";
+    public static final String DB_USER = "root";
+    public static final String DB_PASSWORD = "test";
+}
+

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerMain.java
@@ -1,6 +1,7 @@
 package com.stkych.rivergreenap.controller;
 
 import com.stkych.rivergreenap.RiverGreenDB;
+import com.stkych.rivergreenap.DatabaseConfig;
 import com.stkych.rivergreenap.SceneSwitcher;
 import com.stkych.rivergreenap.controller.cells.TreatmentPlanProcedureCellFactory;
 import com.stkych.rivergreenap.model.RulesetItem;
@@ -191,7 +192,11 @@ public class ControllerMain extends Controller {
      */
     private void loadProceduresForPatient(int patientNumber) throws SQLException {
         // Get procedures for the patient using the RiverGreenDB class
-        ObservableList<TreatmentPlanProcedure> loadedProcedures = RiverGreenDB.getProceduresForPatientObservable(patientNumber);
+        ObservableList<TreatmentPlanProcedure> loadedProcedures = RiverGreenDB.getProceduresForPatientObservable(
+            patientNumber,
+            DatabaseConfig.DB_URL,
+            DatabaseConfig.DB_USER,
+            DatabaseConfig.DB_PASSWORD);
 
         // Create a new list with the header item at the beginning
         ObservableList<TreatmentPlanProcedure> proceduresWithHeader = FXCollections.observableArrayList();
@@ -233,7 +238,10 @@ public class ControllerMain extends Controller {
      */
     private void setupPriorityListView() {
         try {
-            ObservableList<String> priorities = RiverGreenDB.getAllPrioritiesObservable();
+            ObservableList<String> priorities = RiverGreenDB.getAllPrioritiesObservable(
+                DatabaseConfig.DB_URL,
+                DatabaseConfig.DB_USER,
+                DatabaseConfig.DB_PASSWORD);
             sortPriorities(priorities);
             priorityListView.setItems(priorities);
         } catch (SQLException e) {
@@ -376,7 +384,10 @@ public class ControllerMain extends Controller {
      */
     private void setupDiagnosisListView() {
         try {
-            ObservableList<String> diagnoses = RiverGreenDB.getAllDiagnosesObservable();
+            ObservableList<String> diagnoses = RiverGreenDB.getAllDiagnosesObservable(
+                DatabaseConfig.DB_URL,
+                DatabaseConfig.DB_USER,
+                DatabaseConfig.DB_PASSWORD);
             diagnosisListView.setItems(diagnoses);
         } catch (SQLException e) {
             handleError(e);

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerRuleset.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/ControllerRuleset.java
@@ -1,6 +1,7 @@
 package com.stkych.rivergreenap.controller;
 
 import com.stkych.rivergreenap.RiverGreenDB;
+import com.stkych.rivergreenap.DatabaseConfig;
 import com.stkych.rivergreenap.SceneSwitcher;
 import com.stkych.rivergreenap.controller.cells.RulesetItemCellFactory;
 import com.stkych.rivergreenap.model.RulesetItem;
@@ -1081,7 +1082,10 @@ public class ControllerRuleset implements Initializable {
         ObservableList<String> priorities;
         try {
             // Get priorities from the database
-            priorities = RiverGreenDB.getAllPrioritiesObservable();
+            priorities = RiverGreenDB.getAllPrioritiesObservable(
+                DatabaseConfig.DB_URL,
+                DatabaseConfig.DB_USER,
+                DatabaseConfig.DB_PASSWORD);
             // Sort the priorities
             sortPriorities(priorities);
         } catch (SQLException e) {

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/RulesetDialogController.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/controller/RulesetDialogController.java
@@ -1,6 +1,7 @@
 package com.stkych.rivergreenap.controller;
 
 import com.stkych.rivergreenap.RiverGreenDB;
+import com.stkych.rivergreenap.DatabaseConfig;
 import com.stkych.rivergreenap.util.DentalCodeUtil;
 import com.stkych.rivergreenap.util.TeethNotationUtil;
 import javafx.collections.FXCollections;
@@ -69,7 +70,10 @@ public class RulesetDialogController implements Initializable {
     public void initialize(URL location, ResourceBundle resources) {
         // Initialize priority combo box
         try {
-            ObservableList<String> priorities = RiverGreenDB.getAllPrioritiesObservable();
+            ObservableList<String> priorities = RiverGreenDB.getAllPrioritiesObservable(
+                DatabaseConfig.DB_URL,
+                DatabaseConfig.DB_USER,
+                DatabaseConfig.DB_PASSWORD);
             priorityComboBox.setItems(priorities);
         } catch (SQLException e) {
             showErrorAlert("Error loading priorities", e.getMessage());
@@ -77,7 +81,10 @@ public class RulesetDialogController implements Initializable {
 
         // Initialize diagnosis combo box
         try {
-            ObservableList<String> diagnoses = RiverGreenDB.getAllDiagnosesObservable();
+            ObservableList<String> diagnoses = RiverGreenDB.getAllDiagnosesObservable(
+                DatabaseConfig.DB_URL,
+                DatabaseConfig.DB_USER,
+                DatabaseConfig.DB_PASSWORD);
             diagnosisComboBox.setItems(diagnoses);
         } catch (SQLException e) {
             showErrorAlert("Error loading diagnoses", e.getMessage());


### PR DESCRIPTION
## Summary
- Add `DatabaseConfig` to hold database URL, user, and password.
- Update `RiverGreenDB` methods to accept connection details as arguments with overloads using defaults.
- Adjust controllers to pass the database credentials when accessing data.

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4be16689483279aee46ab9ae45a2e