### PR TITLE
Allow DB config via command-line arguments

### DIFF
--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/DatabaseConfig.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/DatabaseConfig.java
@@ -4,8 +4,20 @@ package com.stkych.rivergreenap;
  * Configuration values for connecting to the database.
  */
 public class DatabaseConfig {
-    public static final String DB_URL = "jdbc:mysql://localhost:3306/opendental?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC";
-    public static final String DB_USER = "root";
-    public static final String DB_PASSWORD = "test";
+    public static String DB_URL = "jdbc:mysql://localhost:3306/opendental?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC";
+    public static String DB_USER = "root";
+    public static String DB_PASSWORD = "test";
+
+    public static void setConnection(String url, String user, String password) {
+        if (url != null && !url.isBlank()) {
+            DB_URL = url;
+        }
+        if (user != null && !user.isBlank()) {
+            DB_USER = user;
+        }
+        if (password != null && !password.isBlank()) {
+            DB_PASSWORD = password;
+        }
+    }
 }
 

--- a/rivergreen-ap/src/main/java/com/stkych/rivergreenap/RiverGreenApplication.java
+++ b/rivergreen-ap/src/main/java/com/stkych/rivergreenap/RiverGreenApplication.java
@@ -55,7 +55,6 @@ public class RiverGreenApplication extends Application {
      * @param args Command line arguments. If provided, the first argument should be the patient number.
      */
     public static void main(String[] args) {
-        // Check if a patient number was provided as a command line argument
         if (args.length > 0) {
             try {
                 patientNumber = Integer.parseInt(args[0]);
@@ -63,6 +62,12 @@ public class RiverGreenApplication extends Application {
                 LOGGER.log(Level.WARNING, "Invalid patient number format. Using default: " + patientNumber);
             }
         }
+
+        String url = args.length > 1 ? args[1] : null;
+        String user = args.length > 2 ? args[2] : null;
+        String password = args.length > 3 ? args[3] : null;
+        DatabaseConfig.setConnection(url, user, password);
+
         launch(args);
     }
 }


### PR DESCRIPTION
## Summary
- Allow DB connection details to be overridden through command-line arguments.
- Replace constant database fields with mutable ones and add `setConnection` helper.

## Testing
- `mvn -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0eb99a09c832793d8808ca36be5f3